### PR TITLE
Cloudflare Pages compatibility

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -30,7 +30,7 @@
       }
 
       #image {
-        background-image: url(https://clouds.matteason.co.uk/images/4096x2048/earth.jpg);
+        background-image: url(./images/4096x2048/earth.jpg);
         background-size: cover;
         background-position: center right;
         background-repeat: no-repeat;
@@ -124,7 +124,7 @@
         }
 
         #image {
-          background-image: url(https://clouds.matteason.co.uk/images/1024x512/earth.jpg);
+          background-image: url(./images/1024x512/earth.jpg);
           width: 100%;
           aspect-ratio: 2;
           position: relative;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 console.log(`Generating cloud maps...`);
 
-const SOURCE_WIDTH = 4096;
+const SOURCE_WIDTH = 8192;
 const SOURCE_HEIGHT = SOURCE_WIDTH/2;
 
 const WEBSITE_OUTPUT_DIR = './out';

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ function processImages() {
   saveImageResolutions(specularBase, 'specular', ['jpg']);
 
   // Copy website assets
-  fs.cpSync('./html', './out', {
+  fs.cpSync('./html', WEBSITE_OUTPUT_DIR, {
     recursive: true,
   });
 }
@@ -426,6 +426,8 @@ function saveImageResolutions(image, filename, formats) {
       clone
         .resize(SOURCE_WIDTH/scale, SOURCE_HEIGHT/scale)
         .quality(80)
+        .deflateLevel(9)
+        .colorType(4)
         .write(`${outputSubdir}/${filename}.${format}`)
     }
   })

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 console.log(`Generating cloud maps...`);
 
-const SOURCE_WIDTH = 1024;
+const SOURCE_WIDTH = 2048;
 const SOURCE_HEIGHT = SOURCE_WIDTH/2;
 
 const WEBSITE_OUTPUT_DIR = './out';

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 console.log(`Generating cloud maps...`);
 
-const SOURCE_WIDTH = 2048;
+const SOURCE_WIDTH = 4096;
 const SOURCE_HEIGHT = SOURCE_WIDTH/2;
 
 const WEBSITE_OUTPUT_DIR = './out';

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ console.log(`Generating cloud maps...`);
 const SOURCE_WIDTH = 1024;
 const SOURCE_HEIGHT = SOURCE_WIDTH/2;
 
+const WEBSITE_OUTPUT_DIR = './out';
 const OUTPUT_DIR = './out/images';
 const TEMP_DIR = './tmp';
 
@@ -398,6 +399,11 @@ function processImages() {
     });
 
   saveImageResolutions(specularBase, 'specular', ['jpg']);
+
+  // Copy website assets
+  fs.cpSync('./html', './out', {
+    recursive: true,
+  });
 }
 
 function saveImageResolutions(image, filename, formats) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 console.log(`Generating cloud maps...`);
 
-const SOURCE_WIDTH = 8192;
+const SOURCE_WIDTH = 1024;
 const SOURCE_HEIGHT = SOURCE_WIDTH/2;
 
 const OUTPUT_DIR = './out/images';


### PR DESCRIPTION
Fixes to make compatible with Cloudflare pages:

- Copy landing page assets to output directory
- Relative URL for landing page background image to ensure it shows correctly on preview builds
- Improved PNG compression to ensure images are under CF's 25MB asset limit